### PR TITLE
Report connection as closed if internal flag is set or libpq knows that connection is closed.

### DIFF
--- a/psycopg2ct/_impl/connection.py
+++ b/psycopg2ct/_impl/connection.py
@@ -361,7 +361,7 @@ class Connection(object):
 
     @property
     def closed(self):
-        return self._closed
+        return self._closed or (libpq.PQstatus(self._pgconn) == libpq.CONNECTION_BAD)
 
     @check_closed
     def xid(self, format_id, gtrid, bqual):


### PR DESCRIPTION
This fixes problem when connection is closed on backend side and
conn.closed() still reports False, while conn.fileno() would return -1,
indicating that connection is broken.

It is strange though, that even the implementation of closed() is the same in psycopg2 and psycopg2-ctypes, psycopg2 doesn't expose this problem.
