### PR TITLE
Bugfix in copy_expert method

### DIFF
--- a/psycopg2ct/_impl/cursor.py
+++ b/psycopg2ct/_impl/cursor.py
@@ -468,11 +468,13 @@ class Cursor(object):
             raise TypeError("file must be a readable file-like object for"
                 " COPY FROM; a writeable file-like object for COPY TO.")
 
+        self._copysize = size
         self._copyfile = file
         try:
             self._pq_execute(sql)
         finally:
             self._copyfile = None
+            self._copysize = None
 
     @check_closed
     def setinputsizes(self, sizes):


### PR DESCRIPTION
To be perfectly honest, I'm not exactly sure what the purpose of this change is; it's one commit written by a predecessor who's no longer at our organization.  Apparently, though, not setting the _copysize property in this method broke one of our applications.  Anyhow, now that I've inherited this codebase, I'm trying to get its various dependencies synced with upstream so we're not maintaining forks.

If this doesn't seem sane or merge-worthy at first glance, I can track down my former colleague and see if I can get a more detailed justification and/or test-case before you merge.
